### PR TITLE
Rancher fix

### DIFF
--- a/src/main/java/dev/terrarium/minefactoryrenewed/MinefactoryRenewed.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/MinefactoryRenewed.java
@@ -6,6 +6,7 @@ import dev.terrarium.minefactoryrenewed.compat.top.TOPCompat;
 import dev.terrarium.minefactoryrenewed.data.generator.*;
 import dev.terrarium.minefactoryrenewed.data.machine.PickableReloadListener;
 import dev.terrarium.minefactoryrenewed.data.machine.PlantableReloadListener;
+import dev.terrarium.minefactoryrenewed.data.machine.RanchableReloadListener;
 import dev.terrarium.minefactoryrenewed.item.SafariNetItem;
 import dev.terrarium.minefactoryrenewed.item.syringe.SyringeItem;
 import dev.terrarium.minefactoryrenewed.network.ModPackets;
@@ -90,6 +91,7 @@ public class MinefactoryRenewed {
     private void reloadListenerEvent(AddReloadListenerEvent event) {
         event.addListener(new PlantableReloadListener());
         event.addListener(new PickableReloadListener());
+        event.addListener(new RanchableReloadListener());
         event.addListener(new PinkReloadListener());
         event.addListener(new PotionReloadListener());
         event.addListener(new ExplosiveReloadListener());

--- a/src/main/java/dev/terrarium/minefactoryrenewed/api/item/Ranchable.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/api/item/Ranchable.java
@@ -1,30 +1,53 @@
 package dev.terrarium.minefactoryrenewed.api.item;
 
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.registries.ForgeRegistries;
 
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
 public record Ranchable(EntityType<?> entityType,
-                        Item tool,
-                        boolean consumeTool,
-                        Function<LivingEntity, ItemStack> resultFunction,
+                        Item tool, ToolInteractType interactType, int damage,
+                        Function<LivingEntity, List<ItemStack>> resultFunction,
                         Predicate<LivingEntity> entityPredicate,
                         Consumer<LivingEntity> consumer) {
 
-    public Ranchable(EntityType<?> entityType, Item tool, boolean consumeTool, Function<LivingEntity, ItemStack> resultFunction) {
-        this(entityType, tool, consumeTool, resultFunction, entity -> true, entity -> {});
+    public static final Codec<Ranchable> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            ForgeRegistries.ENTITIES.getCodec().fieldOf("entity").forGetter(Ranchable::entityType),
+            ForgeRegistries.ITEMS.getCodec().fieldOf("tool").forGetter(Ranchable::tool),
+            ToolInteractType.CODEC.fieldOf("interactType").orElse(ToolInteractType.NOTHING).forGetter(Ranchable::interactType),
+            Codec.INT.fieldOf("damage").orElse(0).forGetter(Ranchable::damage),
+            ItemStack.CODEC.fieldOf("result").forGetter(ranchable -> ItemStack.EMPTY)
+    ).apply(instance, Ranchable::new));
+
+    public Ranchable(EntityType<?> entityType, Item tool, ToolInteractType interactType, int damage, ItemStack result) {
+        this(entityType, tool, interactType, damage, entity -> List.of(result), entity -> true, entity -> {});
     }
 
-    public Ranchable(EntityType<?> entityType, Item tool, boolean consumeTool, ItemStack result) {
-        this(entityType, tool, consumeTool, entity -> result, entity -> true, entity -> {});
+    public static Ranchable ofConsumable(EntityType<?> entityType, Item tool, Function<LivingEntity, List<ItemStack>> resultFunction, Predicate<LivingEntity> entityPredicate, Consumer<LivingEntity> consumer) {
+        return new Ranchable(entityType, tool, ToolInteractType.CONSUME, 0, resultFunction, entityPredicate, consumer);
     }
 
-    public ItemStack result(LivingEntity entity) {
+    public static Ranchable ofDamaging(EntityType<?> entityType, Item tool, int damage, Function<LivingEntity, List<ItemStack>> resultFunction, Predicate<LivingEntity> entityPredicate, Consumer<LivingEntity> consumer) {
+        return new Ranchable(entityType, tool, ToolInteractType.DAMAGING, damage, resultFunction, entityPredicate, consumer);
+    }
+
+    public List<ItemStack> result(LivingEntity entity) {
         return resultFunction.apply(entity);
+    }
+
+    public enum ToolInteractType {
+        CONSUME,
+        DAMAGING,
+        NOTHING;
+
+        public static final Codec<ToolInteractType> CODEC = Codec.STRING.xmap(ToolInteractType::valueOf, ToolInteractType::name);
     }
 }

--- a/src/main/java/dev/terrarium/minefactoryrenewed/blockentity/generator/CreativeEnergyBlockEntity.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/blockentity/generator/CreativeEnergyBlockEntity.java
@@ -43,8 +43,6 @@ public class CreativeEnergyBlockEntity extends GeneratorBlockEntity {
 
     @Override
     public Component getDisplayText() {
-        return canGenerate() ?
-                new TranslatableComponent("tooltip.generator." + MinefactoryRenewed.MODID + ".generating", String.valueOf(getEnergyGen())) :
-                new TranslatableComponent("tooltip.generator." + MinefactoryRenewed.MODID + ".idle");
+        return new TranslatableComponent("tooltip." + MinefactoryRenewed.MODID + ".generator." + (canGenerate() ? "generating" : "idle"), String.valueOf(getEnergyGen()));
     }
 }

--- a/src/main/java/dev/terrarium/minefactoryrenewed/blockentity/generator/EthanolGeneratorBlockEntity.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/blockentity/generator/EthanolGeneratorBlockEntity.java
@@ -1,5 +1,6 @@
 package dev.terrarium.minefactoryrenewed.blockentity.generator;
 
+import dev.terrarium.minefactoryrenewed.MinefactoryRenewed;
 import dev.terrarium.minefactoryrenewed.blockentity.container.generator.EthanolGeneratorContainer;
 import dev.terrarium.minefactoryrenewed.registry.ModBlockEntities;
 import dev.terrarium.minefactoryrenewed.registry.ModBlocks;
@@ -40,9 +41,7 @@ public class EthanolGeneratorBlockEntity extends GeneratorBlockEntity {
 
     @Override
     public Component getDisplayText() {
-        return getTank().getFluidAmount() >= FLUID_COST && canGenerate() ?
-                new TranslatableComponent("tooltip.generator.generating", String.valueOf(getEnergyGen())) :
-                new TranslatableComponent("tooltip.generator.idle");
+        return new TranslatableComponent("tooltip." + MinefactoryRenewed.MODID + ".generator." + (getTank().getFluidAmount() >= FLUID_COST && canGenerate() ? "generating" : "idle"), String.valueOf(getEnergyGen()));
     }
 
     @Override

--- a/src/main/java/dev/terrarium/minefactoryrenewed/blockentity/generator/SteamTurbineBlockEntity.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/blockentity/generator/SteamTurbineBlockEntity.java
@@ -1,5 +1,6 @@
 package dev.terrarium.minefactoryrenewed.blockentity.generator;
 
+import dev.terrarium.minefactoryrenewed.MinefactoryRenewed;
 import dev.terrarium.minefactoryrenewed.blockentity.container.generator.SteamTurbineContainer;
 import dev.terrarium.minefactoryrenewed.registry.ModBlockEntities;
 import dev.terrarium.minefactoryrenewed.registry.ModBlocks;
@@ -41,9 +42,7 @@ public class SteamTurbineBlockEntity extends GeneratorBlockEntity {
 
     @Override
     public Component getDisplayText() {
-        return getTank().getFluidAmount() >= FLUID_COST && canGenerate() ?
-                new TranslatableComponent("tooltip.generator.generating", String.valueOf(getEnergyGen())) :
-                new TranslatableComponent("tooltip.generator.idle");
+        return new TranslatableComponent("tooltip." + MinefactoryRenewed.MODID + ".generator." + (getTank().getFluidAmount() >= FLUID_COST && canGenerate() ? "generating" : "idle"), String.valueOf(getEnergyGen()));
     }
 
     @Override

--- a/src/main/java/dev/terrarium/minefactoryrenewed/blockentity/machine/MachineBlockEntity.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/blockentity/machine/MachineBlockEntity.java
@@ -20,6 +20,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.entity.EntityTypeTest;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.energy.CapabilityEnergy;
@@ -54,6 +55,20 @@ public abstract class MachineBlockEntity extends BaseBlockEntity {
             entity instanceof Animal &&
             entity.canChangeDimensions()
     );
+
+    protected static final EntityTypeTest<Entity, LivingEntity> LIVING_ENTITY_TEST = new EntityTypeTest<>() {
+        @Nullable
+        @Override
+        public LivingEntity tryCast(@NotNull Entity entity) {
+            return entity instanceof LivingEntity living ? living : null;
+        }
+
+        @NotNull
+        @Override
+        public Class<? extends Entity> getBaseClass() {
+            return LivingEntity.class;
+        }
+    };
 
     //Cache directions array
     protected static final Direction[] DIRECTIONS = Direction.values();

--- a/src/main/java/dev/terrarium/minefactoryrenewed/data/GenericReloadListener.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/data/GenericReloadListener.java
@@ -1,4 +1,4 @@
-package dev.terrarium.minefactoryrenewed.data.generator;
+package dev.terrarium.minefactoryrenewed.data;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -15,21 +15,27 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Map;
 import java.util.function.Consumer;
 
-public class GeneratorReloadListener<T> extends SimpleJsonResourceReloadListener {
+public class GenericReloadListener<T> extends SimpleJsonResourceReloadListener {
 
     private static final Gson GSON = new GsonBuilder().create();
     private static final String FOLDER_ID = "generators";
     private final Codec<T> dataType;
     private final Consumer<T> consumer;
     private final String path;
+    private final String folder;
     private final Runnable clear;
 
-    public GeneratorReloadListener(String path, Codec<T> dataType, Consumer<T> consumer, Runnable clear) {
-        super(GSON, FOLDER_ID);
+    public GenericReloadListener(String path, Codec<T> dataType, Consumer<T> consumer, Runnable clear, String folder) {
+        super(GSON, folder);
+        this.folder = folder;
         this.path = path;
         this.dataType = dataType;
         this.consumer = consumer;
         this.clear = clear;
+    }
+
+    public GenericReloadListener(String path, Codec<T> dataType, Consumer<T> consumer, Runnable clear) {
+        this(path, dataType, consumer, clear, FOLDER_ID);
     }
 
     @Override
@@ -39,10 +45,10 @@ public class GeneratorReloadListener<T> extends SimpleJsonResourceReloadListener
 
         for (Map.Entry<ResourceLocation, JsonElement> entry : elements.entrySet()) {
             ResourceLocation id = entry.getKey();
-            if (!id.getNamespace().equals(MinefactoryRenewed.MODID) || !id.getPath().startsWith(path + "/")) continue;
+            if (!id.getNamespace().equals(MinefactoryRenewed.MODID) || (path != null && !id.getPath().startsWith(path + "/"))) continue;
             T dataEntry = dataType.parse(JsonOps.INSTANCE, entry.getValue().getAsJsonObject())
                     .getOrThrow(false, s ->
-                            MinefactoryRenewed.LOGGER.error("Unable to load" + path + "data for {}, \n{}", id.toString(), s));
+                            MinefactoryRenewed.LOGGER.error("Unable to load" + (path != null ? path : folder) + "data for {}, \n{}", id.toString(), s));
             consumer.accept(dataEntry);
         }
     }

--- a/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/DeathReloadListener.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/DeathReloadListener.java
@@ -1,8 +1,9 @@
 package dev.terrarium.minefactoryrenewed.data.generator;
 
 import dev.terrarium.minefactoryrenewed.api.item.GeneratorItem;
+import dev.terrarium.minefactoryrenewed.data.GenericReloadListener;
 
-public class DeathReloadListener extends GeneratorReloadListener<GeneratorItem> {
+public class DeathReloadListener extends GenericReloadListener<GeneratorItem> {
 
     public DeathReloadListener() {
         super("death", GeneratorItem.CODEC, GeneratorItemManager.getDeath()::addEntry, GeneratorItemManager.getDeath()::clear);

--- a/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/DisenchantmentReloadListener.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/DisenchantmentReloadListener.java
@@ -1,20 +1,9 @@
 package dev.terrarium.minefactoryrenewed.data.generator;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
-import com.mojang.serialization.JsonOps;
-import dev.terrarium.minefactoryrenewed.MinefactoryRenewed;
 import dev.terrarium.minefactoryrenewed.api.item.Disenchantment;
-import dev.terrarium.minefactoryrenewed.api.item.Hellish;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.packs.resources.ResourceManager;
-import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
-import net.minecraft.util.profiling.ProfilerFiller;
+import dev.terrarium.minefactoryrenewed.data.GenericReloadListener;
 
-import java.util.Map;
-
-public class DisenchantmentReloadListener extends GeneratorReloadListener<Disenchantment> {
+public class DisenchantmentReloadListener extends GenericReloadListener<Disenchantment> {
 
     public DisenchantmentReloadListener() {
         super("disenchantment", Disenchantment.CODEC, DisenchantmentManager.getInstance()::addEntry, DisenchantmentManager.getInstance()::clear);

--- a/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/EnderReloadListener.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/EnderReloadListener.java
@@ -1,8 +1,9 @@
 package dev.terrarium.minefactoryrenewed.data.generator;
 
 import dev.terrarium.minefactoryrenewed.api.item.GeneratorItem;
+import dev.terrarium.minefactoryrenewed.data.GenericReloadListener;
 
-public class EnderReloadListener extends GeneratorReloadListener<GeneratorItem> {
+public class EnderReloadListener extends GenericReloadListener<GeneratorItem> {
 
     public EnderReloadListener() {
         super("ender", GeneratorItem.CODEC, GeneratorItemManager.getEnder()::addEntry, GeneratorItemManager.getEnder()::clear);

--- a/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/ExplosiveReloadListener.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/ExplosiveReloadListener.java
@@ -1,8 +1,9 @@
 package dev.terrarium.minefactoryrenewed.data.generator;
 
 import dev.terrarium.minefactoryrenewed.api.item.GeneratorItem;
+import dev.terrarium.minefactoryrenewed.data.GenericReloadListener;
 
-public class ExplosiveReloadListener extends GeneratorReloadListener<GeneratorItem> {
+public class ExplosiveReloadListener extends GenericReloadListener<GeneratorItem> {
 
     public ExplosiveReloadListener() {
         super("explosive", GeneratorItem.CODEC, GeneratorItemManager.getExplosive()::addEntry, GeneratorItemManager.getExplosive()::clear);

--- a/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/FrostyReloadListener.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/FrostyReloadListener.java
@@ -1,8 +1,9 @@
 package dev.terrarium.minefactoryrenewed.data.generator;
 
 import dev.terrarium.minefactoryrenewed.api.item.GeneratorItem;
+import dev.terrarium.minefactoryrenewed.data.GenericReloadListener;
 
-public class FrostyReloadListener extends GeneratorReloadListener<GeneratorItem> {
+public class FrostyReloadListener extends GenericReloadListener<GeneratorItem> {
 
     public FrostyReloadListener() {
         super("frosty", GeneratorItem.CODEC, GeneratorItemManager.getFrosty()::addEntry, GeneratorItemManager.getFrosty()::clear);

--- a/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/HellishReloadListener.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/HellishReloadListener.java
@@ -1,8 +1,9 @@
 package dev.terrarium.minefactoryrenewed.data.generator;
 
 import dev.terrarium.minefactoryrenewed.api.item.Hellish;
+import dev.terrarium.minefactoryrenewed.data.GenericReloadListener;
 
-public class HellishReloadListener extends GeneratorReloadListener<Hellish> {
+public class HellishReloadListener extends GenericReloadListener<Hellish> {
 
     public HellishReloadListener() {
         super("hellish", Hellish.CODEC, HellishManager.getInstance()::addEntry, HellishManager.getInstance()::clear);

--- a/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/PinkReloadListener.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/PinkReloadListener.java
@@ -1,8 +1,9 @@
 package dev.terrarium.minefactoryrenewed.data.generator;
 
 import dev.terrarium.minefactoryrenewed.api.item.GeneratorItem;
+import dev.terrarium.minefactoryrenewed.data.GenericReloadListener;
 
-public class PinkReloadListener extends GeneratorReloadListener<GeneratorItem> {
+public class PinkReloadListener extends GenericReloadListener<GeneratorItem> {
 
     public PinkReloadListener() {
         super("pink", GeneratorItem.CODEC, GeneratorItemManager.getPink()::addEntry, GeneratorItemManager.getPink()::clear);

--- a/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/PotionReloadListener.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/PotionReloadListener.java
@@ -1,8 +1,9 @@
 package dev.terrarium.minefactoryrenewed.data.generator;
 
 import dev.terrarium.minefactoryrenewed.api.item.PotionData;
+import dev.terrarium.minefactoryrenewed.data.GenericReloadListener;
 
-public class PotionReloadListener extends GeneratorReloadListener<PotionData> {
+public class PotionReloadListener extends GenericReloadListener<PotionData> {
 
     public PotionReloadListener() {
         super("potion", PotionData.CODEC, PotionManager.getInstance()::addEntry, PotionManager.getInstance()::clear);

--- a/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/SlimeyReloadListener.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/data/generator/SlimeyReloadListener.java
@@ -1,8 +1,9 @@
 package dev.terrarium.minefactoryrenewed.data.generator;
 
 import dev.terrarium.minefactoryrenewed.api.item.GeneratorItem;
+import dev.terrarium.minefactoryrenewed.data.GenericReloadListener;
 
-public class SlimeyReloadListener extends GeneratorReloadListener<GeneratorItem> {
+public class SlimeyReloadListener extends GenericReloadListener<GeneratorItem> {
 
     public SlimeyReloadListener() {
         super("slimey", GeneratorItem.CODEC, GeneratorItemManager.getSlimey()::addEntry, GeneratorItemManager.getSlimey()::clear);

--- a/src/main/java/dev/terrarium/minefactoryrenewed/data/machine/RanchManager.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/data/machine/RanchManager.java
@@ -1,78 +1,45 @@
 package dev.terrarium.minefactoryrenewed.data.machine;
 
-import com.google.common.collect.Maps;
 import dev.terrarium.minefactoryrenewed.api.item.Ranchable;
-import net.minecraft.Util;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.animal.Cow;
 import net.minecraft.world.entity.animal.MushroomCow;
 import net.minecraft.world.entity.animal.Sheep;
-import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.level.ItemLike;
-import net.minecraft.world.level.block.Blocks;
 
 import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
-public class RanchManager {
+public class RanchManager extends HashMap<EntityType<?>, Ranchable> {
 
     private static final RanchManager INSTANCE = new RanchManager();
-    private final Map<EntityType<?>, Ranchable> ranchables = new HashMap<>();
-    //Copied from Sheep for now bcs stupid private
-    private static final Map<DyeColor, ItemLike> WOOL_COLORS = Util.make(Maps.newEnumMap(DyeColor.class), (map) -> {
-        map.put(DyeColor.WHITE, Blocks.WHITE_WOOL);
-        map.put(DyeColor.ORANGE, Blocks.ORANGE_WOOL);
-        map.put(DyeColor.MAGENTA, Blocks.MAGENTA_WOOL);
-        map.put(DyeColor.LIGHT_BLUE, Blocks.LIGHT_BLUE_WOOL);
-        map.put(DyeColor.YELLOW, Blocks.YELLOW_WOOL);
-        map.put(DyeColor.LIME, Blocks.LIME_WOOL);
-        map.put(DyeColor.PINK, Blocks.PINK_WOOL);
-        map.put(DyeColor.GRAY, Blocks.GRAY_WOOL);
-        map.put(DyeColor.LIGHT_GRAY, Blocks.LIGHT_GRAY_WOOL);
-        map.put(DyeColor.CYAN, Blocks.CYAN_WOOL);
-        map.put(DyeColor.PURPLE, Blocks.PURPLE_WOOL);
-        map.put(DyeColor.BLUE, Blocks.BLUE_WOOL);
-        map.put(DyeColor.BROWN, Blocks.BROWN_WOOL);
-        map.put(DyeColor.GREEN, Blocks.GREEN_WOOL);
-        map.put(DyeColor.RED, Blocks.RED_WOOL);
-        map.put(DyeColor.BLACK, Blocks.BLACK_WOOL);
-    });
 
-    public RanchManager() {
-        addRanchable(new Ranchable(EntityType.SHEEP, Items.SHEARS, false,
-                entity -> entity instanceof Sheep sheep ? new ItemStack(WOOL_COLORS.get(sheep.getColor())) : ItemStack.EMPTY,
+    private RanchManager() {
+        addEntry(Ranchable.ofDamaging(EntityType.SHEEP, Items.SHEARS, 1,
+                entity -> entity instanceof Sheep sheep ? sheep.onSheared(null, ItemStack.EMPTY, sheep.level, sheep.blockPosition(), 0) : List.of(ItemStack.EMPTY),
                 entity -> entity instanceof Sheep sheep && sheep.readyForShearing(),
-                entity -> {
-                    if (entity instanceof Sheep sheep)
-                        sheep.setSheared(true);
-                }
+                entity -> {}
         ));
 
-        addRanchable(new Ranchable(EntityType.COW, Items.BUCKET, true,
-                entity -> new ItemStack(Items.MILK_BUCKET),
+        addEntry(Ranchable.ofConsumable(EntityType.COW, Items.BUCKET,
+                entity -> List.of(new ItemStack(Items.MILK_BUCKET)),
                 entity -> entity instanceof Cow && !(entity instanceof MushroomCow),
-                entity -> {
-                }
+                entity -> {}
         ));
 
-        addRanchable(new Ranchable(EntityType.MOOSHROOM, Items.BOWL, true, new ItemStack(Items.MUSHROOM_STEW)));
-        addRanchable(new Ranchable(EntityType.SQUID, null, false, new ItemStack(Items.INK_SAC)));
-        addRanchable(new Ranchable(EntityType.GLOW_SQUID, null, false, new ItemStack(Items.GLOW_INK_SAC)));
+        addEntry(new Ranchable(EntityType.MOOSHROOM, Items.BOWL, Ranchable.ToolInteractType.CONSUME, 0, new ItemStack(Items.MUSHROOM_STEW)));
+        addEntry(new Ranchable(EntityType.SQUID, null, Ranchable.ToolInteractType.NOTHING, 0, new ItemStack(Items.INK_SAC)));
+        addEntry(new Ranchable(EntityType.GLOW_SQUID, null, Ranchable.ToolInteractType.NOTHING, 0, new ItemStack(Items.GLOW_INK_SAC)));
     }
 
-    public void addRanchable(Ranchable ranchable) {
-        this.ranchables.put(ranchable.entityType(), ranchable);
+    public void addEntry(Ranchable ranchable) {
+        put(ranchable.entityType(), ranchable);
     }
 
-    public boolean hasRanchable(LivingEntity entity) {
-        return ranchables.containsKey(entity.getType());
-    }
-
-    public Ranchable getRanchable(LivingEntity entity) {
-        return ranchables.get(entity.getType());
+    public Ranchable getEntry(LivingEntity entity) {
+        return get(entity.getType());
     }
 
     public static RanchManager getInstance() {

--- a/src/main/java/dev/terrarium/minefactoryrenewed/data/machine/RanchableReloadListener.java
+++ b/src/main/java/dev/terrarium/minefactoryrenewed/data/machine/RanchableReloadListener.java
@@ -1,0 +1,11 @@
+package dev.terrarium.minefactoryrenewed.data.machine;
+
+import dev.terrarium.minefactoryrenewed.api.item.Ranchable;
+import dev.terrarium.minefactoryrenewed.data.GenericReloadListener;
+
+public class RanchableReloadListener extends GenericReloadListener<Ranchable> {
+
+    public RanchableReloadListener() {
+        super(null, Ranchable.CODEC, RanchManager.getInstance()::addEntry, RanchManager.getInstance()::clear, "rancher");
+    }
+}


### PR DESCRIPTION
Fix rancher to allow for rancher results to be datapackable.
Allow for damaging of tools in a rancher.
Change how sheep are sheared to result in a list of wools.
Moved and refactored GeneratorReloadListener to suit more than just generators.

Fixed generator translation keys.